### PR TITLE
Add transfer failure handling

### DIFF
--- a/fungible-token/Cargo.toml
+++ b/fungible-token/Cargo.toml
@@ -16,3 +16,6 @@ gtest.workspace = true
 [build-dependencies]
 fungible-token-io.workspace = true
 gear-wasm-builder.workspace = true
+
+[features]
+test = []

--- a/fungible-token/io/src/lib.rs
+++ b/fungible-token/io/src/lib.rs
@@ -50,6 +50,7 @@ pub enum FTAction {
     BalanceOf(ActorId),
     Mint(u128),
     Burn(u128),
+    FailNextTransfer,
 }
 
 #[derive(Debug, Encode, Decode, TypeInfo)]

--- a/fungible-token/io/src/lib.rs
+++ b/fungible-token/io/src/lib.rs
@@ -50,7 +50,7 @@ pub enum FTAction {
     BalanceOf(ActorId),
     Mint(u128),
     Burn(u128),
-    FailNextTransfer,
+    SetFailTransferFlag(bool),
 }
 
 #[derive(Debug, Encode, Decode, TypeInfo)]

--- a/fungible-token/src/lib.rs
+++ b/fungible-token/src/lib.rs
@@ -12,7 +12,7 @@ const ZERO_ID: ActorId = ActorId::new([0u8; 32]);
 #[derive(Debug, Clone, Default)]
 struct Config {
     #[allow(dead_code)]
-    pub fail_next_transfer: bool
+    pub fail_transfer: bool
 }
 type ValidUntil = u64;
 type TxId = u64;
@@ -87,9 +87,7 @@ impl FungibleToken {
     fn transfer(&mut self, tx_id: Option<u64>, from: &ActorId, to: &ActorId, amount: u128)->Result<(), FTError> {
         #[cfg(feature = "test")]
         {
-            let fail = &mut self.config.fail_next_transfer;
-            if *fail {
-                *fail = false;
+            if self.config.fail_transfer {
                 panic!("Test panic")
             }
         }
@@ -279,11 +277,10 @@ extern fn handle() {
             let balance = ft.balances.get(&account).unwrap_or(&0);
             msg::reply::<FTEvent>(FTEvent::Balance(*balance), 0).unwrap();
         }
-        FTAction::FailNextTransfer => {
+        FTAction::SetFailTransferFlag(fail) => {
             #[cfg(feature="test")]
             {
-                let fail = &mut ft.config.fail_next_transfer;
-                *fail = true;
+                ft.config.fail_transfer = fail;
             }
         }
     }

--- a/io/src/lib.rs
+++ b/io/src/lib.rs
@@ -87,12 +87,16 @@ pub enum InvariantAction {
         position_id: u32,
     },
     WithdrawProtocolFee(PoolKey),
+    ClaimLostTokens {
+        token: ActorId,
+    },
 }
 
 #[derive(Clone, Decode, Encode, Debug, PartialEq, Eq, TypeInfo)]
 #[codec(crate = gstd::codec)]
 #[scale_info(crate = gstd::scale_info)]
 pub enum InvariantEvent {
+    ActionFailed(InvariantError),
     ProtocolFeeChanged(Percentage),
     PositionCreatedReturn(Position),
     PositionCreatedEvent {
@@ -135,7 +139,6 @@ pub enum InvariantEvent {
     Quote(QuoteResult),
     QuoteRoute(TokenAmount),
     ClaimFee(TokenAmount, TokenAmount),
-    ActionFailed(InvariantError),
 }
 
 #[derive(Clone, Decode, Encode, Debug, TypeInfo)]
@@ -151,12 +154,14 @@ pub enum InvariantStateQuery {
     GetTick(PoolKey, i32),
     IsTickInitialized(PoolKey, i32),
     GetAllPositions(ActorId),
+    GetUserBalances(ActorId),
 }
 
 #[derive(Encode, Decode, Clone, PartialEq, Eq, Debug, TypeInfo)]
 #[codec(crate = gstd::codec)]
 #[scale_info(crate = gstd::scale_info)]
 pub enum InvariantStateReply {
+    QueryFailed(InvariantError),
     ProtocolFee(Percentage),
     QueriedFeeTiers(Vec<FeeTier>),
     FeeTierExist(bool),
@@ -166,7 +171,7 @@ pub enum InvariantStateReply {
     Positions(Vec<Position>),
     Tick(Tick),
     IsTickInitialized(bool),
-    QueryFailed(InvariantError),
+    UserBalances(Vec<(ActorId, TokenAmount)>),
 }
 
 #[derive(Decode, Default, Encode, Clone, Debug, PartialEq, Eq, TypeInfo)]

--- a/src/contracts/errors.rs
+++ b/src/contracts/errors.rs
@@ -23,6 +23,8 @@ pub enum InvariantError {
   PoolKeyAlreadyExist,
   UnauthorizedFeeReceiver,
   ZeroLiquidity,
+  RecoverableTransferError,
+  UnrecoverableTransferError,
   TransferError,
   TokensAreSame,
   AmountUnderMinimumAmountOut,
@@ -31,9 +33,10 @@ pub enum InvariantError {
   InvalidInitTick,
   InvalidInitSqrtPrice,
   NotEnoughGasToExecute,
-  NotEnoughGasToUpdate,
   TickLimitReached,
-  InvalidTickIndex
+  InvalidTickIndex,
+  NoBalanceForTheToken,
+  FailedToChangeTokenBalance,
 }
 
 impl Into<String>for InvariantError {

--- a/src/e2e/gtest/claim_lost_tokens.rs
+++ b/src/e2e/gtest/claim_lost_tokens.rs
@@ -47,7 +47,7 @@ fn test_swap_transfer_fail_token_x() {
     let slippage = SqrtPrice::new(MAX_SQRT_PRICE);
 
     token_x_program
-        .send(REGULAR_USER_2, FTAction::FailNextTransfer)
+        .send(REGULAR_USER_2, FTAction::SetFailTransferFlag(true))
         .assert_success();
 
     let _res = invariant.send_and_assert_error(
@@ -134,7 +134,7 @@ fn test_claim_lost_tokens_after_swap_token_y() {
     let slippage = SqrtPrice::new(MIN_SQRT_PRICE);
 
     token_y_program
-        .send(REGULAR_USER_2, FTAction::FailNextTransfer)
+        .send(REGULAR_USER_2, FTAction::SetFailTransferFlag(true))
         .assert_success();
 
     let _res = invariant.send_and_assert_error(

--- a/src/e2e/gtest/claim_lost_tokens.rs
+++ b/src/e2e/gtest/claim_lost_tokens.rs
@@ -1,0 +1,190 @@
+use crate::test_helpers::gtest::consts::*;
+use crate::test_helpers::gtest::*;
+
+use contracts::*;
+use decimal::*;
+use fungible_token_io::*;
+use gstd::*;
+use gtest::*;
+use io::*;
+use math::{
+    fee_growth::FeeGrowth, percentage::Percentage, sqrt_price::SqrtPrice,
+    token_amount::TokenAmount, MAX_SQRT_PRICE, MIN_SQRT_PRICE,
+};
+
+#[test]
+fn test_swap_transfer_fail_token_x() {
+    let sys = System::new();
+    sys.init_logger();
+    let token_x: ActorId = TOKEN_X_ID.into();
+    let token_y: ActorId = TOKEN_Y_ID.into();
+
+    let (token_x_program, token_y_program) = init_tokens(&sys);
+    let mut invariant = init_invariant(&sys, Percentage::from_scale(1, 2));
+
+    init_basic_pool(&invariant, &token_x, &token_y);
+    init_basic_position(&sys, &invariant, &token_x_program, &token_y_program);
+    let fee = Percentage::from_scale(6, 3);
+    let tick_spacing = 10;
+    let fee_tier = FeeTier { fee, tick_spacing };
+    let pool_key = PoolKey::new(token_x, token_y, fee_tier).unwrap();
+
+    let amount = 500;
+    assert!(!token_y_program
+        .send(REGULAR_USER_2, FTAction::Mint(amount))
+        .main_failed());
+
+    increase_allowance(&token_y_program, REGULAR_USER_2, INVARIANT_ID, amount).assert_success();
+
+    assert_eq!(balance_of(&token_y_program, REGULAR_USER_2), 500);
+
+    assert_eq!(balance_of(&token_x_program, INVARIANT_ID), 500);
+    assert_eq!(balance_of(&token_y_program, INVARIANT_ID), 1000);
+
+    let pool_before = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
+
+    let swap_amount = TokenAmount::new(amount);
+    let slippage = SqrtPrice::new(MAX_SQRT_PRICE);
+
+    token_x_program
+        .send(REGULAR_USER_2, FTAction::FailNextTransfer)
+        .assert_success();
+
+    let _res = invariant.send_and_assert_error(
+        REGULAR_USER_2,
+        InvariantAction::Swap {
+            pool_key,
+            x_to_y: false,
+            amount: swap_amount,
+            by_amount_in: true,
+            sqrt_price_limit: slippage,
+        },
+        InvariantError::RecoverableTransferError,
+    );
+
+    let pool_after = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
+
+    assert_eq!(pool_before, pool_after);
+
+    assert_eq!(balance_of(&token_x_program, REGULAR_USER_2), 0);
+    assert_eq!(balance_of(&token_y_program, REGULAR_USER_2), 0);
+
+    assert_eq!(
+        vec![(ActorId::from(TOKEN_Y_ID), swap_amount)],
+        get_user_balances(&invariant, REGULAR_USER_2)
+    );
+
+    assert_eq!(balance_of(&token_x_program, INVARIANT_ID), 500);
+    assert_eq!(balance_of(&token_y_program, INVARIANT_ID), 1000 + 500);
+
+    assert_eq!(pool_after.fee_growth_global_x, FeeGrowth::new(0));
+    assert_eq!(pool_after.fee_growth_global_y, FeeGrowth::new(0));
+
+    assert_eq!(pool_after.fee_protocol_token_x, TokenAmount::new(0));
+    assert_eq!(pool_after.fee_protocol_token_y, TokenAmount::new(0));
+
+    invariant
+        .send(
+            REGULAR_USER_2,
+            InvariantAction::ClaimLostTokens {
+                token: TOKEN_Y_ID.into(),
+            },
+        )
+        .assert_success();
+
+    assert_eq!(balance_of(&token_x_program, REGULAR_USER_2), 0);
+    assert_eq!(balance_of(&token_y_program, REGULAR_USER_2), 500);
+
+    assert_eq!(balance_of(&token_x_program, INVARIANT_ID), 500);
+    assert_eq!(balance_of(&token_y_program, INVARIANT_ID), 1000);
+}
+
+#[test]
+fn test_claim_lost_tokens_after_swap_token_y() {
+    let sys = System::new();
+    sys.init_logger();
+    let token_x: ActorId = TOKEN_X_ID.into();
+    let token_y: ActorId = TOKEN_Y_ID.into();
+
+    let (token_x_program, token_y_program) = init_tokens(&sys);
+    let mut invariant = init_invariant(&sys, Percentage::from_scale(1, 2));
+
+    init_basic_pool(&invariant, &token_x, &token_y);
+    init_basic_position(&sys, &invariant, &token_x_program, &token_y_program);
+    let fee = Percentage::from_scale(6, 3);
+    let tick_spacing = 10;
+    let fee_tier = FeeTier { fee, tick_spacing };
+    let pool_key = PoolKey::new(token_x, token_y, fee_tier).unwrap();
+
+    let amount = 500;
+    assert!(!token_x_program
+        .send(REGULAR_USER_2, FTAction::Mint(amount))
+        .main_failed());
+
+    increase_allowance(&token_x_program, REGULAR_USER_2, INVARIANT_ID, amount).assert_success();
+
+    assert_eq!(balance_of(&token_x_program, REGULAR_USER_2), 500);
+
+    assert_eq!(balance_of(&token_x_program, INVARIANT_ID), 500);
+    assert_eq!(balance_of(&token_y_program, INVARIANT_ID), 1000);
+
+    let pool_before = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
+
+    let swap_amount = TokenAmount::new(amount);
+    let slippage = SqrtPrice::new(MIN_SQRT_PRICE);
+
+    token_y_program
+        .send(REGULAR_USER_2, FTAction::FailNextTransfer)
+        .assert_success();
+
+    let _res = invariant.send_and_assert_error(
+        REGULAR_USER_2,
+        InvariantAction::Swap {
+            pool_key,
+            x_to_y: true,
+            amount: swap_amount,
+            by_amount_in: true,
+            sqrt_price_limit: slippage,
+        },
+        InvariantError::RecoverableTransferError,
+    );
+
+    let pool_after = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
+
+    assert_eq!(pool_before, pool_after);
+
+    assert_eq!(balance_of(&token_x_program, REGULAR_USER_2), 0);
+    assert_eq!(balance_of(&token_y_program, REGULAR_USER_2), 0);
+
+    assert_eq!(
+        vec![(ActorId::from(TOKEN_X_ID), swap_amount)],
+        get_user_balances(&invariant, REGULAR_USER_2)
+    );
+
+    assert_eq!(
+        balance_of(&token_x_program, INVARIANT_ID),
+        500 + swap_amount.get()
+    );
+    assert_eq!(balance_of(&token_y_program, INVARIANT_ID), 1000);
+
+    assert_eq!(pool_after.fee_growth_global_x, FeeGrowth::new(0));
+    assert_eq!(pool_after.fee_growth_global_y, FeeGrowth::new(0));
+
+    assert_eq!(pool_after.fee_protocol_token_x, TokenAmount::new(0));
+    assert_eq!(pool_after.fee_protocol_token_y, TokenAmount::new(0));
+
+    invariant
+        .send(
+            REGULAR_USER_2,
+            InvariantAction::ClaimLostTokens {
+                token: TOKEN_X_ID.into(),
+            },
+        )
+        .assert_success();
+
+    assert_eq!(balance_of(&token_x_program, REGULAR_USER_2), 500);
+    assert_eq!(balance_of(&token_y_program, REGULAR_USER_2), 0);
+
+    assert_eq!(balance_of(&token_x_program, INVARIANT_ID), 500);
+    assert_eq!(balance_of(&token_y_program, INVARIANT_ID), 1000);
+}

--- a/src/e2e/gtest/mod.rs
+++ b/src/e2e/gtest/mod.rs
@@ -21,3 +21,4 @@ pub mod liquidity_gap;
 pub mod claim;
 pub mod protocol_fee;
 pub mod interaction_with_pool_on_remove_fee_tier;
+pub mod claim_lost_tokens;

--- a/src/e2e/gtest/position.rs
+++ b/src/e2e/gtest/position.rs
@@ -1362,7 +1362,7 @@ fn test_remove_position_token_x_transfer_fail() {
 
     // Burn all token x to fail transfer
     token_x_program
-        .send(REGULAR_USER_2, FTAction::FailNextTransfer)
+        .send(REGULAR_USER_2, FTAction::SetFailTransferFlag(true))
         .assert_success();
     // Remove position
     invariant.send_and_assert_error(
@@ -1569,7 +1569,7 @@ fn test_remove_position_token_y_transfer_fail() {
 
     // Burn all token x to fail transfer
     token_y_program
-        .send(REGULAR_USER_2, FTAction::FailNextTransfer)
+        .send(REGULAR_USER_2, FTAction::SetFailTransferFlag(true))
         .assert_success();
     // Remove position
     invariant.send_and_assert_error(

--- a/src/e2e/gtest/position.rs
+++ b/src/e2e/gtest/position.rs
@@ -765,7 +765,7 @@ fn test_create_position_not_enough_token_y() {
     let upper_tick_index = 8;
     let liquidity_delta = Liquidity::from_integer(10_000);
 
-    let _res = invariant.send_and_assert_panic(
+    let _res = invariant.send_and_assert_error(
         REGULAR_USER_1,
         InvariantAction::CreatePosition {
             pool_key,
@@ -775,7 +775,12 @@ fn test_create_position_not_enough_token_y() {
             slippage_limit_lower: pool_state_before.sqrt_price,
             slippage_limit_upper: pool_state_before.sqrt_price,
         },
-        InvariantError::TransferError,
+        InvariantError::RecoverableTransferError,
+    );
+
+    assert_eq!(
+        vec![(ActorId::from(TOKEN_Y_ID), TokenAmount(4))],
+        get_user_balances(&invariant, REGULAR_USER_1.into())
     );
 
     let pool_state = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
@@ -789,9 +794,9 @@ fn test_create_position_not_enough_token_y() {
     let invariant_x = balance_of(&token_x_program, INVARIANT_ID.into());
     let invariant_y = balance_of(&token_y_program, INVARIANT_ID.into());
 
-    assert_eq!(invariant_x, 0);
+    assert_eq!(invariant_x, 4);
     assert_eq!(invariant_y, 0);
-    assert_eq!(user_1_x, initial_balance);
+    assert_eq!(user_1_x, initial_balance - 4);
     assert_eq!(user_1_y, 1);
     assert_eq!(&pool_state, &pool_state_before);
 }
@@ -953,7 +958,7 @@ fn test_create_position_insufficient_allowance_token_y() {
     let upper_tick_index = 8;
     let liquidity_delta = Liquidity::from_integer(10_000);
 
-    let _res = invariant.send_and_assert_panic(
+    let _res = invariant.send_and_assert_error(
         REGULAR_USER_1,
         InvariantAction::CreatePosition {
             pool_key,
@@ -963,7 +968,7 @@ fn test_create_position_insufficient_allowance_token_y() {
             slippage_limit_lower: pool_state_before.sqrt_price,
             slippage_limit_upper: pool_state_before.sqrt_price,
         },
-        InvariantError::TransferError,
+        InvariantError::RecoverableTransferError,
     );
 
     let pool_state = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
@@ -977,9 +982,14 @@ fn test_create_position_insufficient_allowance_token_y() {
     let invariant_x = balance_of(&token_x_program, INVARIANT_ID.into());
     let invariant_y = balance_of(&token_y_program, INVARIANT_ID.into());
 
-    assert_eq!(invariant_x, 0);
+    assert_eq!(
+        vec![(ActorId::from(TOKEN_X_ID), TokenAmount(4))],
+        get_user_balances(&invariant, REGULAR_USER_1.into())
+    );
+
+    assert_eq!(invariant_x, 4);
     assert_eq!(invariant_y, 0);
-    assert_eq!(user_1_x, initial_balance);
+    assert_eq!(user_1_x, initial_balance - 4);
     assert_eq!(user_1_y, initial_balance);
     assert_eq!(&pool_state, &pool_state_before);
 }
@@ -1176,6 +1186,422 @@ fn test_remove_position() {
         expected_withdrawn_y
     );
 
+    // Check ticks
+    assert_eq!(lower_tick, Err(InvariantError::TickNotFound));
+    assert_eq!(upper_tick, Err(InvariantError::TickNotFound));
+
+    // Check tickmap
+    assert!(!lower_tick_bit);
+    assert!(!upper_tick_bit);
+
+    // Check pool
+    assert!(pool_state.liquidity == liquidity_delta);
+    assert!(pool_state.current_tick_index == -10);
+}
+
+#[test]
+fn test_remove_position_token_x_transfer_fail() {
+    let sys = System::new();
+    sys.init_logger();
+
+    let token_x = ActorId::from(TOKEN_X_ID);
+    let token_y = ActorId::from(TOKEN_Y_ID);
+
+    let initial_mint = 10u128.pow(10);
+    let mut invariant = init_invariant(&sys, Percentage::from_scale(1, 2));
+    let (token_x_program, token_y_program) = init_tokens(&sys);
+
+    let fee_tier = FeeTier::new(Percentage::from_scale(6, 3), 10).unwrap();
+    let init_tick = 0;
+    let init_sqrt_price = calculate_sqrt_price(init_tick).unwrap();
+    let remove_position_index = 0;
+
+    let pool_key = PoolKey::new(token_x, token_y, fee_tier).unwrap();
+
+    invariant
+        .send(ADMIN, InvariantAction::AddFeeTier(fee_tier))
+        .assert_success();
+
+    invariant
+        .send(
+            REGULAR_USER_1,
+            InvariantAction::CreatePool {
+                token_0: token_x,
+                token_1: token_y,
+                fee_tier,
+                init_sqrt_price,
+                init_tick,
+            },
+        )
+        .assert_success();
+
+    let lower_tick_index = -20;
+    let upper_tick_index = 10;
+    let liquidity_delta = Liquidity::from_integer(1_000_000);
+
+    token_x_program
+        .send(REGULAR_USER_1, FTAction::Mint(initial_mint))
+        .assert_success();
+    token_y_program
+        .send(REGULAR_USER_1, FTAction::Mint(initial_mint))
+        .assert_success();
+
+    increase_allowance(&token_x_program, REGULAR_USER_1, INVARIANT_ID, initial_mint)
+        .assert_success();
+    increase_allowance(&token_y_program, REGULAR_USER_1, INVARIANT_ID, initial_mint)
+        .assert_success();
+
+    let pool_state = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
+
+    invariant
+        .send(
+            REGULAR_USER_1,
+            InvariantAction::CreatePosition {
+                pool_key,
+                lower_tick: lower_tick_index,
+                upper_tick: upper_tick_index,
+                liquidity_delta,
+                slippage_limit_lower: pool_state.sqrt_price,
+                slippage_limit_upper: pool_state.sqrt_price,
+            },
+        )
+        .assert_success();
+
+    let pool_state = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
+
+    assert_eq!(pool_state.liquidity, liquidity_delta);
+
+    let liquidity_delta = Liquidity::new(liquidity_delta.get() * 1_000_000);
+    let incorrect_lower_tick_index = lower_tick_index - 50;
+    let incorrect_upper_tick_index = upper_tick_index + 50;
+
+    increase_allowance(
+        &token_x_program,
+        REGULAR_USER_1,
+        INVARIANT_ID,
+        liquidity_delta.get(),
+    )
+    .assert_success();
+    increase_allowance(
+        &token_y_program,
+        REGULAR_USER_1,
+        INVARIANT_ID,
+        liquidity_delta.get(),
+    )
+    .assert_success();
+
+    invariant
+        .send(
+            REGULAR_USER_1,
+            InvariantAction::CreatePosition {
+                pool_key,
+                lower_tick: incorrect_lower_tick_index,
+                upper_tick: incorrect_upper_tick_index,
+                liquidity_delta,
+                slippage_limit_lower: pool_state.sqrt_price,
+                slippage_limit_upper: pool_state.sqrt_price,
+            },
+        )
+        .assert_success();
+
+    let position_state = get_position(&invariant, REGULAR_USER_1.into(), 1).unwrap();
+
+    // Check position
+    assert!(position_state.lower_tick_index == incorrect_lower_tick_index);
+    assert!(position_state.upper_tick_index == incorrect_upper_tick_index);
+
+    let amount = 1000;
+    token_x_program
+        .send(REGULAR_USER_2, FTAction::Mint(amount))
+        .assert_success();
+    assert_eq!(balance_of(&token_x_program, REGULAR_USER_2), amount);
+
+    increase_allowance(&token_x_program, REGULAR_USER_2, INVARIANT_ID, amount).assert_success();
+
+    let pool_state_before = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
+
+    let swap_amount = TokenAmount::new(amount);
+    let slippage = SqrtPrice::new(MIN_SQRT_PRICE);
+    invariant
+        .send(
+            REGULAR_USER_2,
+            InvariantAction::Swap {
+                pool_key,
+                x_to_y: true,
+                amount: swap_amount,
+                by_amount_in: true,
+                sqrt_price_limit: slippage,
+            },
+        )
+        .assert_success();
+
+    let pool_state_after = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
+    assert_eq!(
+        pool_state_after.fee_growth_global_x,
+        FeeGrowth::new(49999950000049999)
+    );
+    assert_eq!(pool_state_after.fee_protocol_token_x, TokenAmount(1));
+    assert_eq!(pool_state_after.fee_protocol_token_y, TokenAmount(0));
+
+    assert!(pool_state_after
+        .sqrt_price
+        .lt(&pool_state_before.sqrt_price));
+
+    assert_eq!(pool_state_after.liquidity, pool_state_before.liquidity);
+    assert_eq!(pool_state_after.current_tick_index, -10);
+    assert_ne!(pool_state_after.sqrt_price, pool_state_before.sqrt_price);
+
+    let amount_x = balance_of(&token_x_program, REGULAR_USER_2);
+    let amount_y = balance_of(&token_y_program, REGULAR_USER_2);
+    assert_eq!(amount_x, 0);
+    assert_eq!(amount_y, 993);
+
+    // pre load dex balances
+    let invariant_x_before_remove = balance_of(&token_x_program, INVARIANT_ID);
+    let invariant_y_before_remove = balance_of(&token_y_program, INVARIANT_ID);
+
+    // Burn all token x to fail transfer
+    token_x_program
+        .send(REGULAR_USER_2, FTAction::FailNextTransfer)
+        .assert_success();
+    // Remove position
+    invariant.send_and_assert_error(
+        REGULAR_USER_1,
+        InvariantAction::RemovePosition {
+            position_id: remove_position_index,
+        },
+        InvariantError::RecoverableTransferError,
+    );
+
+    assert_eq!(
+        vec![
+            (ActorId::from(TOKEN_X_ID), TokenAmount(499)),
+            (ActorId::from(TOKEN_Y_ID), TokenAmount(999))
+        ],
+        get_user_balances(&invariant, REGULAR_USER_1.into())
+    );
+
+    // Load states
+    let pool_state = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
+    let lower_tick = get_tick(&invariant, pool_key, lower_tick_index);
+    let upper_tick = get_tick(&invariant, pool_key, lower_tick_index);
+    let lower_tick_bit = is_tick_initialized(&invariant, pool_key, lower_tick_index);
+    let upper_tick_bit = is_tick_initialized(&invariant, pool_key, upper_tick_index);
+    let invariant_x = balance_of(&token_x_program, INVARIANT_ID);
+    let invariant_y = balance_of(&token_y_program, INVARIANT_ID);
+
+    assert_eq!(invariant_x_before_remove, invariant_x);
+    assert_eq!(invariant_y_before_remove, invariant_y);
+
+    // Check ticks
+    assert_eq!(lower_tick, Err(InvariantError::TickNotFound));
+    assert_eq!(upper_tick, Err(InvariantError::TickNotFound));
+
+    // Check tickmap
+    assert!(!lower_tick_bit);
+    assert!(!upper_tick_bit);
+
+    // Check pool
+    assert!(pool_state.liquidity == liquidity_delta);
+    assert!(pool_state.current_tick_index == -10);
+}
+
+#[test]
+fn test_remove_position_token_y_transfer_fail() {
+    let sys = System::new();
+    sys.init_logger();
+
+    let token_x = ActorId::from(TOKEN_X_ID);
+    let token_y = ActorId::from(TOKEN_Y_ID);
+
+    let initial_mint = 10u128.pow(10);
+    let mut invariant = init_invariant(&sys, Percentage::from_scale(1, 2));
+    let (token_x_program, token_y_program) = init_tokens(&sys);
+
+    let fee_tier = FeeTier::new(Percentage::from_scale(6, 3), 10).unwrap();
+    let init_tick = 0;
+    let init_sqrt_price = calculate_sqrt_price(init_tick).unwrap();
+    let remove_position_index = 0;
+
+    let pool_key = PoolKey::new(token_x, token_y, fee_tier).unwrap();
+
+    invariant
+        .send(ADMIN, InvariantAction::AddFeeTier(fee_tier))
+        .assert_success();
+
+    invariant
+        .send(
+            REGULAR_USER_1,
+            InvariantAction::CreatePool {
+                token_0: token_x,
+                token_1: token_y,
+                fee_tier,
+                init_sqrt_price,
+                init_tick,
+            },
+        )
+        .assert_success();
+
+    let lower_tick_index = -20;
+    let upper_tick_index = 10;
+    let liquidity_delta = Liquidity::from_integer(1_000_000);
+
+    token_x_program
+        .send(REGULAR_USER_1, FTAction::Mint(initial_mint))
+        .assert_success();
+    token_y_program
+        .send(REGULAR_USER_1, FTAction::Mint(initial_mint))
+        .assert_success();
+
+    increase_allowance(&token_x_program, REGULAR_USER_1, INVARIANT_ID, initial_mint)
+        .assert_success();
+    increase_allowance(&token_y_program, REGULAR_USER_1, INVARIANT_ID, initial_mint)
+        .assert_success();
+
+    let pool_state = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
+
+    invariant
+        .send(
+            REGULAR_USER_1,
+            InvariantAction::CreatePosition {
+                pool_key,
+                lower_tick: lower_tick_index,
+                upper_tick: upper_tick_index,
+                liquidity_delta,
+                slippage_limit_lower: pool_state.sqrt_price,
+                slippage_limit_upper: pool_state.sqrt_price,
+            },
+        )
+        .assert_success();
+
+    let pool_state = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
+
+    assert_eq!(pool_state.liquidity, liquidity_delta);
+
+    let liquidity_delta = Liquidity::new(liquidity_delta.get() * 1_000_000);
+    let incorrect_lower_tick_index = lower_tick_index - 50;
+    let incorrect_upper_tick_index = upper_tick_index + 50;
+
+    increase_allowance(
+        &token_x_program,
+        REGULAR_USER_1,
+        INVARIANT_ID,
+        liquidity_delta.get(),
+    )
+    .assert_success();
+    increase_allowance(
+        &token_y_program,
+        REGULAR_USER_1,
+        INVARIANT_ID,
+        liquidity_delta.get(),
+    )
+    .assert_success();
+
+    invariant
+        .send(
+            REGULAR_USER_1,
+            InvariantAction::CreatePosition {
+                pool_key,
+                lower_tick: incorrect_lower_tick_index,
+                upper_tick: incorrect_upper_tick_index,
+                liquidity_delta,
+                slippage_limit_lower: pool_state.sqrt_price,
+                slippage_limit_upper: pool_state.sqrt_price,
+            },
+        )
+        .assert_success();
+
+    let position_state = get_position(&invariant, REGULAR_USER_1.into(), 1).unwrap();
+
+    // Check position
+    assert!(position_state.lower_tick_index == incorrect_lower_tick_index);
+    assert!(position_state.upper_tick_index == incorrect_upper_tick_index);
+
+    let amount = 1000;
+    token_x_program
+        .send(REGULAR_USER_2, FTAction::Mint(amount))
+        .assert_success();
+    assert_eq!(balance_of(&token_x_program, REGULAR_USER_2), amount);
+
+    increase_allowance(&token_x_program, REGULAR_USER_2, INVARIANT_ID, amount).assert_success();
+
+    let pool_state_before = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
+
+    let swap_amount = TokenAmount::new(amount);
+    let slippage = SqrtPrice::new(MIN_SQRT_PRICE);
+    invariant
+        .send(
+            REGULAR_USER_2,
+            InvariantAction::Swap {
+                pool_key,
+                x_to_y: true,
+                amount: swap_amount,
+                by_amount_in: true,
+                sqrt_price_limit: slippage,
+            },
+        )
+        .assert_success();
+
+    let pool_state_after = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
+    assert_eq!(
+        pool_state_after.fee_growth_global_x,
+        FeeGrowth::new(49999950000049999)
+    );
+    assert_eq!(pool_state_after.fee_protocol_token_x, TokenAmount(1));
+    assert_eq!(pool_state_after.fee_protocol_token_y, TokenAmount(0));
+
+    assert!(pool_state_after
+        .sqrt_price
+        .lt(&pool_state_before.sqrt_price));
+
+    assert_eq!(pool_state_after.liquidity, pool_state_before.liquidity);
+    assert_eq!(pool_state_after.current_tick_index, -10);
+    assert_ne!(pool_state_after.sqrt_price, pool_state_before.sqrt_price);
+
+    let amount_x = balance_of(&token_x_program, REGULAR_USER_2);
+    let amount_y = balance_of(&token_y_program, REGULAR_USER_2);
+    assert_eq!(amount_x, 0);
+    assert_eq!(amount_y, 993);
+
+    // pre load dex balances
+    let invariant_x_before_remove = balance_of(&token_x_program, INVARIANT_ID);
+    let invariant_y_before_remove = balance_of(&token_y_program, INVARIANT_ID);
+
+    // Burn all token x to fail transfer
+    token_y_program
+        .send(REGULAR_USER_2, FTAction::FailNextTransfer)
+        .assert_success();
+    // Remove position
+    invariant.send_and_assert_error(
+        REGULAR_USER_1,
+        InvariantAction::RemovePosition {
+            position_id: remove_position_index,
+        },
+        InvariantError::RecoverableTransferError,
+    );
+
+    // Load states
+    let pool_state = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
+    let lower_tick = get_tick(&invariant, pool_key, lower_tick_index);
+    let upper_tick = get_tick(&invariant, pool_key, lower_tick_index);
+    let lower_tick_bit = is_tick_initialized(&invariant, pool_key, lower_tick_index);
+    let upper_tick_bit = is_tick_initialized(&invariant, pool_key, upper_tick_index);
+
+    let invariant_x = balance_of(&token_x_program, INVARIANT_ID);
+    let invariant_y = balance_of(&token_y_program, INVARIANT_ID);
+
+    let expected_withdrawn_x = 499;
+    let expected_fee_x = 0;
+
+    assert_eq!(
+        invariant_x_before_remove - invariant_x,
+        expected_withdrawn_x + expected_fee_x
+    );
+
+    assert_eq!(invariant_y_before_remove, invariant_y);
+
+    let balances = get_user_balances(&invariant, REGULAR_USER_1.into());
+    assert_eq!(balances, vec![(token_y, TokenAmount(999))]);
     // Check ticks
     assert_eq!(lower_tick, Err(InvariantError::TickNotFound));
     assert_eq!(upper_tick, Err(InvariantError::TickNotFound));

--- a/src/e2e/gtest/position.rs
+++ b/src/e2e/gtest/position.rs
@@ -779,7 +779,7 @@ fn test_create_position_not_enough_token_y() {
     );
 
     assert_eq!(
-        vec![(ActorId::from(TOKEN_Y_ID), TokenAmount(4))],
+        vec![(ActorId::from(TOKEN_X_ID), TokenAmount(4))],
         get_user_balances(&invariant, REGULAR_USER_1.into())
     );
 

--- a/src/e2e/gtest/swap.rs
+++ b/src/e2e/gtest/swap.rs
@@ -772,7 +772,7 @@ fn test_swap_transfer_fail_token_x() {
     let slippage = SqrtPrice::new(MAX_SQRT_PRICE);
 
     token_x_program
-        .send(REGULAR_USER_2, FTAction::FailNextTransfer)
+        .send(REGULAR_USER_2, FTAction::SetFailTransferFlag(true))
         .assert_success();
 
     let _res = invariant.send_and_assert_error(
@@ -844,7 +844,7 @@ fn test_swap_transfer_fail_token_y() {
     let slippage = SqrtPrice::new(MIN_SQRT_PRICE);
 
     token_y_program
-        .send(REGULAR_USER_2, FTAction::FailNextTransfer)
+        .send(REGULAR_USER_2, FTAction::SetFailTransferFlag(true))
         .assert_success();
 
     let _res = invariant.send_and_assert_error(

--- a/src/e2e/gtest/swap.rs
+++ b/src/e2e/gtest/swap.rs
@@ -736,3 +736,150 @@ fn test_swap_y_to_x() {
     assert!(middle_tick_bit);
     assert!(upper_tick_bit);
 }
+
+#[test]
+fn test_swap_transfer_fail_token_x() {
+    let sys = System::new();
+    sys.init_logger();
+    let token_x: ActorId = TOKEN_X_ID.into();
+    let token_y: ActorId = TOKEN_Y_ID.into();
+
+    let (token_x_program, token_y_program) = init_tokens(&sys);
+    let mut invariant = init_invariant(&sys, Percentage::from_scale(1, 2));
+
+    init_basic_pool(&invariant, &token_x, &token_y);
+    init_basic_position(&sys, &invariant, &token_x_program, &token_y_program);
+    let fee = Percentage::from_scale(6, 3);
+    let tick_spacing = 10;
+    let fee_tier = FeeTier { fee, tick_spacing };
+    let pool_key = PoolKey::new(token_x, token_y, fee_tier).unwrap();
+
+    let amount = 500;
+    assert!(!token_y_program
+        .send(REGULAR_USER_2, FTAction::Mint(amount))
+        .main_failed());
+
+    increase_allowance(&token_y_program, REGULAR_USER_2, INVARIANT_ID, amount).assert_success();
+
+    assert_eq!(balance_of(&token_y_program, REGULAR_USER_2), 500);
+
+    assert_eq!(balance_of(&token_x_program, INVARIANT_ID), 500);
+    assert_eq!(balance_of(&token_y_program, INVARIANT_ID), 1000);
+
+    let pool_before = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
+
+    let swap_amount = TokenAmount::new(amount);
+    let slippage = SqrtPrice::new(MAX_SQRT_PRICE);
+
+    token_x_program
+        .send(REGULAR_USER_2, FTAction::FailNextTransfer)
+        .assert_success();
+
+    let _res = invariant.send_and_assert_error(
+        REGULAR_USER_2,
+        InvariantAction::Swap {
+            pool_key,
+            x_to_y: false,
+            amount: swap_amount,
+            by_amount_in: true,
+            sqrt_price_limit: slippage,
+        },
+        InvariantError::RecoverableTransferError,
+    );
+
+    let pool_after = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
+
+    assert_eq!(pool_before, pool_after);
+
+    assert_eq!(balance_of(&token_x_program, REGULAR_USER_2), 0);
+    assert_eq!(balance_of(&token_y_program, REGULAR_USER_2), 0);
+
+    assert_eq!(
+        vec![(ActorId::from(TOKEN_Y_ID), swap_amount)],
+        get_user_balances(&invariant, REGULAR_USER_2)
+    );
+
+    assert_eq!(balance_of(&token_x_program, INVARIANT_ID), 500);
+    assert_eq!(balance_of(&token_y_program, INVARIANT_ID), 1000 + 500);
+
+    assert_eq!(pool_after.fee_growth_global_x, FeeGrowth::new(0));
+    assert_eq!(pool_after.fee_growth_global_y, FeeGrowth::new(0));
+
+    assert_eq!(pool_after.fee_protocol_token_x, TokenAmount::new(0));
+    assert_eq!(pool_after.fee_protocol_token_y, TokenAmount::new(0));
+}
+
+#[test]
+fn test_swap_transfer_fail_token_y() {
+    let sys = System::new();
+    sys.init_logger();
+    let token_x: ActorId = TOKEN_X_ID.into();
+    let token_y: ActorId = TOKEN_Y_ID.into();
+
+    let (token_x_program, token_y_program) = init_tokens(&sys);
+    let mut invariant = init_invariant(&sys, Percentage::from_scale(1, 2));
+
+    init_basic_pool(&invariant, &token_x, &token_y);
+    init_basic_position(&sys, &invariant, &token_x_program, &token_y_program);
+    let fee = Percentage::from_scale(6, 3);
+    let tick_spacing = 10;
+    let fee_tier = FeeTier { fee, tick_spacing };
+    let pool_key = PoolKey::new(token_x, token_y, fee_tier).unwrap();
+
+    let amount = 500;
+    assert!(!token_x_program
+        .send(REGULAR_USER_2, FTAction::Mint(amount))
+        .main_failed());
+
+    increase_allowance(&token_x_program, REGULAR_USER_2, INVARIANT_ID, amount).assert_success();
+
+    assert_eq!(balance_of(&token_x_program, REGULAR_USER_2), 500);
+
+    assert_eq!(balance_of(&token_x_program, INVARIANT_ID), 500);
+    assert_eq!(balance_of(&token_y_program, INVARIANT_ID), 1000);
+
+    let pool_before = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
+
+    let swap_amount = TokenAmount::new(amount);
+    let slippage = SqrtPrice::new(MIN_SQRT_PRICE);
+
+    token_y_program
+        .send(REGULAR_USER_2, FTAction::FailNextTransfer)
+        .assert_success();
+
+    let _res = invariant.send_and_assert_error(
+        REGULAR_USER_2,
+        InvariantAction::Swap {
+            pool_key,
+            x_to_y: true,
+            amount: swap_amount,
+            by_amount_in: true,
+            sqrt_price_limit: slippage,
+        },
+        InvariantError::RecoverableTransferError,
+    );
+
+    let pool_after = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();
+
+    assert_eq!(pool_before, pool_after);
+
+    assert_eq!(balance_of(&token_x_program, REGULAR_USER_2), 0);
+    assert_eq!(balance_of(&token_y_program, REGULAR_USER_2), 0);
+
+    assert_eq!(
+        vec![(ActorId::from(TOKEN_X_ID), swap_amount)],
+        get_user_balances(&invariant, REGULAR_USER_2)
+    );
+
+    assert_eq!(
+        balance_of(&token_x_program, INVARIANT_ID),
+        500 + swap_amount.get()
+    );
+    assert_eq!(balance_of(&token_y_program, INVARIANT_ID), 1000);
+
+    assert_eq!(pool_after.fee_growth_global_x, FeeGrowth::new(0));
+    assert_eq!(pool_after.fee_growth_global_y, FeeGrowth::new(0));
+
+    assert_eq!(pool_after.fee_protocol_token_x, TokenAmount::new(0));
+    assert_eq!(pool_after.fee_protocol_token_y, TokenAmount::new(0));
+}

--- a/src/test_helpers/gtest/entrypoints/get_user_balances.rs
+++ b/src/test_helpers/gtest/entrypoints/get_user_balances.rs
@@ -1,0 +1,16 @@
+use contracts::*;
+use gstd::{ActorId, Vec};
+use gtest::*;
+
+use io::*;
+use math::token_amount::TokenAmount;
+pub fn get_user_balances(invariant: &Program, user: u64) -> Vec<(ActorId, TokenAmount)> {
+    let state: InvariantStateReply = invariant
+        .read_state(InvariantStateQuery::GetUserBalances(user.into()))
+        .expect("Failed to read state");
+    if let InvariantStateReply::UserBalances(balances) = state {
+        return balances;
+    } else {
+        panic!("unexpected state {:?}", state);
+    }
+}

--- a/src/test_helpers/gtest/entrypoints/mod.rs
+++ b/src/test_helpers/gtest/entrypoints/mod.rs
@@ -13,6 +13,7 @@ pub mod get_all_positions;
 pub mod is_tick_initialized;
 pub mod quote;
 pub mod claim_fee;
+pub mod get_user_balances;
 
 pub use utils::*;
 pub use init_invariant::*;
@@ -27,3 +28,4 @@ pub use get_all_positions::*;
 pub use is_tick_initialized::*;
 pub use quote::*;
 pub use claim_fee::*;
+pub use get_user_balances::*;

--- a/tests.sh
+++ b/tests.sh
@@ -1,7 +1,7 @@
 # Build 
 cargo build --release --features debug
 # Build token
-cargo build -p fungible-token --release
+cargo build -p fungible-token --release --features test
 
 # Download node binary
 cargo xtask node


### PR DESCRIPTION
# Changes 
- added option to force fail token transfer for tests
- added storing transfer failures
- made gas checks more consistent for entrypoints with predictable execution costs