### PR TITLE
Remove panic on tick limit reached and fix update tick

### DIFF
--- a/src/contracts/storage/pool.rs
+++ b/src/contracts/storage/pool.rs
@@ -178,7 +178,7 @@ impl Pool {
         let tick_index = match tick {
             UpdatePoolTick::TickInitialized(tick) => {
                 if !x_to_y || is_enough_amount_to_cross {
-                    let _ = tick.cross(self, current_timestamp);
+                    tick.cross(self, current_timestamp).unwrap();
                     has_crossed = true;
                 } else if !remaining_amount.is_zero() {
                     if by_amount_in {

--- a/src/e2e/gtest/swap.rs
+++ b/src/e2e/gtest/swap.rs
@@ -384,7 +384,7 @@ fn test_swap_not_enough_liquidity_token_x() {
             by_amount_in: true,
             sqrt_price_limit: slippage,
         },
-        "tick not in range of <-221818, 221818>",
+        InvariantError::TickLimitReached,
     );
 
     let pool_after = get_pool(&invariant, token_x, token_y, fee_tier).unwrap();


### PR DESCRIPTION
# Changes
- removed panic from reaching tick limit in compute swap
- fixed `pool.update_tick`  to fail on overflow in timestamp or liquidity