### PR TITLE
added support for multiple architectures for the vara node download

### DIFF
--- a/gear-erc20/app/src/services/admin/funcs.rs
+++ b/gear-erc20/app/src/services/admin/funcs.rs
@@ -3,8 +3,8 @@ use crate::services::erc20::{
     utils::{Result, *},
 };
 use sails_rs::ActorId;
+use sails_rs::U256;
 use gstd::Vec;
-use primitive_types::U256;
 
 pub fn mint(
     balances: &mut BalancesMap,
@@ -187,8 +187,8 @@ mod tests {
 
     mod utils {
         use super::{AllowancesMap, BalancesMap};
+        use sails_rs::U256;
         use sails_rs::{ActorId, ToString};
-        use primitive_types::U256;
 
         pub fn allowances_map<const N: usize>(
             content: [(ActorId, ActorId, U256); N],

--- a/gear-erc20/app/src/services/admin/mod.rs
+++ b/gear-erc20/app/src/services/admin/mod.rs
@@ -4,7 +4,7 @@ use crate::{services, ServiceOf};
 use core::marker::PhantomData;
 use gstd::{exec, msg, String};
 use gstd::{ActorId, Decode, Encode, ToString, TypeInfo, Vec};
-use primitive_types::U256;
+use sails_rs::U256;
 use sails_rs::gstd::service;
 use sails_rs::Box;
 use super::erc20::storage::{AllowancesStorage, BalancesStorage, TotalSupplyStorage};

--- a/gear-erc20/app/src/services/aggregated/mod.rs
+++ b/gear-erc20/app/src/services/aggregated/mod.rs
@@ -2,7 +2,7 @@ use crate::{services, ServiceOf};
 use core::marker::PhantomData;
 use gstd::String;
 use gstd::{ActorId, Decode, Encode, ToString, TypeInfo, Vec};
-use primitive_types::U256;
+use sails_rs::U256;
 use sails_rs::format;
 use sails_rs::gstd::service;
 use sails_rs::Box;

--- a/gear-erc20/app/src/services/erc20/funcs.rs
+++ b/gear-erc20/app/src/services/erc20/funcs.rs
@@ -1,6 +1,6 @@
 use super::utils::{Result, *};
 use sails_rs::ActorId;
-use primitive_types::U256;
+use sails_rs::U256;
 
 pub fn allowance(allowances: &AllowancesMap, owner: ActorId, spender: ActorId) -> U256 {
     allowances
@@ -602,7 +602,7 @@ mod tests {
     mod utils {
         use super::{AllowancesMap, BalancesMap};
         use sails_rs::ActorId;
-        use primitive_types::U256;
+        use sails_rs::U256;
 
         pub fn allowances_map<const N: usize>(
             content: [(ActorId, ActorId, U256); N],

--- a/gear-erc20/app/src/services/erc20/mod.rs
+++ b/gear-erc20/app/src/services/erc20/mod.rs
@@ -4,7 +4,7 @@
 use crate::services;
 use core::{cmp::Ordering, fmt::Debug, marker::PhantomData};
 use gstd::{ext, format, Decode, Encode, String, TypeInfo, Vec};
-use primitive_types::U256;
+use sails_rs::U256;
 use sails_rs::gstd::{service, msg};
 use sails_rs::ActorId;
 use sails_rs::Box;

--- a/gear-erc20/app/src/services/erc20/storage.rs
+++ b/gear-erc20/app/src/services/erc20/storage.rs
@@ -1,7 +1,7 @@
 // TODO (sails): impl such macro
 use super::utils::{AllowancesMap, BalancesMap};
 use gstd::String;
-use primitive_types::U256;
+use sails_rs::U256;
 
 crate::declare_storage!(module: allowances, name: AllowancesStorage, ty: AllowancesMap);
 

--- a/gear-erc20/app/src/services/erc20/utils.rs
+++ b/gear-erc20/app/src/services/erc20/utils.rs
@@ -1,5 +1,5 @@
 use gstd::{collections::HashMap, Decode, Encode, TypeInfo};
-use primitive_types::U256;
+use sails_rs::U256;
 use sails_rs::ActorId;
 
 pub type AllowancesMap = HashMap<(ActorId, ActorId), NonZeroU256>;

--- a/gear-erc20/app/src/services/roles/utils.rs
+++ b/gear-erc20/app/src/services/roles/utils.rs
@@ -3,7 +3,7 @@ use gstd::{
     collections::{BTreeSet, HashMap},
     ActorId, Decode, Encode, String, TypeInfo,
 };
-use primitive_types::U256;
+use sails_rs::U256;
 
 // Replace with NonEmptySet
 // Consider array of [bit; RoleNumber]

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -5,6 +5,20 @@ use std::{
 };
 use xshell::Shell;
 
+#[cfg(not(any(
+    all(target_os = "windows", target_arch = "x86_64"),
+    all(target_os = "macos", target_arch = "aarch64"),
+    all(target_os = "linux", target_arch = "x86_64"),
+)))]
+compile_error!("Unsupported target platform! Only the following platforms are supported: Windows (x86_64), macOS (aarch64), or Linux (x86_64).");
+
+#[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+const NODE_LINK: &str = "https://get.gear.rs/gear-v1.4.1-x86_64-pc-windows-msvc.zip";
+
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+const NODE_LINK: &str = "https://get.gear.rs/gear-v1.4.1-aarch64-apple-darwin.tar.xz";
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
 const NODE_LINK: &str = "https://get.gear.rs/gear-v1.4.1-x86_64-unknown-linux-gnu.tar.xz";
 
 fn main() -> Result<()> {


### PR DESCRIPTION
Previously the download link to the Linux Vara node binary was hardcoded. I added support for multiple architectures based on the os and arch of the client machine. Note: Only three types are supported by Gear for v1.4.1.